### PR TITLE
fix compilation error

### DIFF
--- a/examples/common.hpp
+++ b/examples/common.hpp
@@ -2,6 +2,7 @@
 #include <optional>
 #include <vector>
 #include <string>
+#include <cstdint>
 
 #pragma once
 


### PR DESCRIPTION
Missing header for `uint8_t`.

`examples/common.hpp:13:19: error: ‘uint8_t’ was not declared in this scope
   13 | const std::vector<uint8_t> iv = {
      |                   ^~~~~~~
examples/common.hpp:5:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’;` 